### PR TITLE
change for ecto_sql 3.8 compatibility

### DIFF
--- a/lib/ecto_xandra.ex
+++ b/lib/ecto_xandra.ex
@@ -216,6 +216,7 @@ defmodule EctoXandra do
     [{^repo, repo_opts}] = :ets.lookup(:ecto_xandra_opts, repo)
 
     Ecto.Adapters.SQL.execute(
+      :named,
       adapter_meta,
       query_meta,
       query,


### PR DESCRIPTION
in 3.8 `prepared` arg was added https://github.com/elixir-ecto/ecto_sql/blob/c73ba2b1edf9d049804c2103d7dd4c9d28e6c59d/lib/ecto/adapters/sql.ex#L160

https://github.com/elixir-ecto/ecto_sql/pull/372