### PR TITLE
refactor: remove automatic pagination handling in query execution

### DIFF
--- a/lib/ecto_xandra/connection.ex
+++ b/lib/ecto_xandra/connection.ex
@@ -40,7 +40,7 @@ if Code.ensure_loaded?(Xandra) do
         {:ok, %Xandra.Void{}} ->
           {:ok, %{rows: nil, num_rows: 1}}
 
-        {:ok, %Xandra.Page{} = page} ->
+        {:ok, %Xandra.Page{paging_state: nil} = page} ->
           {:ok, process_page(page)}
 
         {:ok, %Xandra.SchemaChange{} = schema_change} ->
@@ -63,7 +63,7 @@ if Code.ensure_loaded?(Xandra) do
           {:ok, %Xandra.Void{}} ->
             {:ok, query, %{rows: nil, num_rows: 1}}
 
-          {:ok, %Xandra.Page{paging_state: nil} = page} ->
+          {:ok, %Xandra.Page{} = page} ->
             {:ok, query, process_page(page)}
 
           {:ok, %Xandra.SchemaChange{} = schema_change} ->
@@ -425,7 +425,7 @@ if Code.ensure_loaded?(Xandra) do
     end
 
     defp expr({:^, [], [_ix]}, _sources, _query) do
-      '?'
+      ~c"?"
     end
 
     defp expr({{:., _, [{:&, _, [_idx]}, field]}, _, []}, _sources, _query)

--- a/lib/ecto_xandra/connection.ex
+++ b/lib/ecto_xandra/connection.ex
@@ -40,7 +40,7 @@ if Code.ensure_loaded?(Xandra) do
         {:ok, %Xandra.Void{}} ->
           {:ok, %{rows: nil, num_rows: 1}}
 
-        {:ok, %Xandra.Page{paging_state: nil} = page} ->
+        {:ok, %Xandra.Page{} = page} ->
           {:ok, process_page(page)}
 
         {:ok, %Xandra.SchemaChange{} = schema_change} ->

--- a/lib/ecto_xandra/connection.ex
+++ b/lib/ecto_xandra/connection.ex
@@ -59,22 +59,19 @@ if Code.ensure_loaded?(Xandra) do
     @impl true
     def execute(cluster, query, params, opts) do
       try do
-        stream = Xandra.Cluster.stream_pages!(cluster, query, params, opts)
+        case Xandra.Cluster.execute(cluster, query, params, opts) do
+          {:ok, %Xandra.Void{}} ->
+            {:ok, query, %{rows: nil, num_rows: 1}}
 
-        result =
-          Enum.reduce_while(stream, %{rows: [], num_rows: 0}, fn
-            %Xandra.Void{}, _acc ->
-              {:halt, %{rows: nil, num_rows: 1}}
+          {:ok, %Xandra.Page{paging_state: nil} = page} ->
+            {:ok, query, process_page(page)}
 
-            %Xandra.SchemaChange{}, _acc ->
-              {:halt, %{rows: nil, num_rows: 1}}
+          {:ok, %Xandra.SchemaChange{} = schema_change} ->
+            {:ok, query, schema_change}
 
-            %Xandra.Page{} = page, %{rows: rows, num_rows: num_rows} ->
-              %{rows: new_rows, num_rows: new_num_rows} = process_page(page)
-              {:cont, %{rows: rows ++ new_rows, num_rows: num_rows + new_num_rows}}
-          end)
-
-        {:ok, query, result}
+          {:error, error} ->
+            {:error, error}
+        end
       rescue
         err ->
           {:error, err}

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule EctoXandra.MixProject do
       {:ecto, "~> 3.11"},
       {:ecto_sql, "~> 3.11"},
       {:nimble_lz4, "~> 0.1.2", optional: true},
-      {:xandra, git: "https://github.com/blueshift-labs/xandra.git", ref: "3fb588a333ae816edeb6bda7d10dc1bad7b6ac96"},
+      {:xandra, git: "https://github.com/blueshift-labs/xandra.git", ref: "9a3cd6e944b19d428192d531c7bb4ec7e498be63"},
       {:jason, "~> 1.2"}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,9 @@ defmodule EctoXandra.MixProject do
       {:ecto, "~> 3.11"},
       {:ecto_sql, "~> 3.11"},
       {:nimble_lz4, "~> 0.1.2", optional: true},
-      {:xandra, git: "https://github.com/blueshift-labs/xandra.git", ref: "9a3cd6e944b19d428192d531c7bb4ec7e498be63"},
+      {:xandra,
+       git: "https://github.com/blueshift-labs/xandra.git",
+       ref: "9a3cd6e944b19d428192d531c7bb4ec7e498be63"},
       {:jason, "~> 1.2"}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule EctoXandra.MixProject do
       {:ecto, "~> 3.11"},
       {:ecto_sql, "~> 3.11"},
       {:nimble_lz4, "~> 0.1.2", optional: true},
-      {:xandra, git: "https://github.com/blueshift-labs/xandra.git", tag: "v0.14.0-bsft-28"},
+      {:xandra, git: "https://github.com/blueshift-labs/xandra.git", ref: "3fb588a333ae816edeb6bda7d10dc1bad7b6ac96"},
       {:jason, "~> 1.2"}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -23,9 +23,7 @@ defmodule EctoXandra.MixProject do
       {:ecto, "~> 3.11"},
       {:ecto_sql, "~> 3.11"},
       {:nimble_lz4, "~> 0.1.2", optional: true},
-      {:xandra,
-       git: "https://github.com/blueshift-labs/xandra.git",
-       ref: "9a3cd6e944b19d428192d531c7bb4ec7e498be63"},
+      {:xandra, git: "https://github.com/blueshift-labs/xandra.git", tag: "v0.14.0-bsft-29"},
       {:jason, "~> 1.2"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -26,5 +26,5 @@
   "toml": {:hex, :toml, "0.7.0", "fbcd773caa937d0c7a02c301a1feea25612720ac3fa1ccb8bfd9d30d822911de", [:mix], [], "hexpm", "0690246a2478c1defd100b0c9b89b4ea280a22be9a7b313a8a058a2408a2fa70"},
   "tzdata": {:hex, :tzdata, "1.1.1", "20c8043476dfda8504952d00adac41c6eda23912278add38edc140ae0c5bcc46", [:mix], [{:hackney, "~> 1.17", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm", "a69cec8352eafcd2e198dea28a34113b60fdc6cb57eb5ad65c10292a6ba89787"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
-  "xandra": {:git, "https://github.com/blueshift-labs/xandra.git", "3fb588a333ae816edeb6bda7d10dc1bad7b6ac96", [ref: "3fb588a333ae816edeb6bda7d10dc1bad7b6ac96"]},
+  "xandra": {:git, "https://github.com/blueshift-labs/xandra.git", "9a3cd6e944b19d428192d531c7bb4ec7e498be63", [ref: "9a3cd6e944b19d428192d531c7bb4ec7e498be63"]},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -26,5 +26,5 @@
   "toml": {:hex, :toml, "0.7.0", "fbcd773caa937d0c7a02c301a1feea25612720ac3fa1ccb8bfd9d30d822911de", [:mix], [], "hexpm", "0690246a2478c1defd100b0c9b89b4ea280a22be9a7b313a8a058a2408a2fa70"},
   "tzdata": {:hex, :tzdata, "1.1.1", "20c8043476dfda8504952d00adac41c6eda23912278add38edc140ae0c5bcc46", [:mix], [{:hackney, "~> 1.17", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm", "a69cec8352eafcd2e198dea28a34113b60fdc6cb57eb5ad65c10292a6ba89787"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
-  "xandra": {:git, "https://github.com/blueshift-labs/xandra.git", "e2d7b41d1a4ff234894d604ff67a6d163fe9abe8", [tag: "v0.14.0-bsft-28"]},
+  "xandra": {:git, "https://github.com/blueshift-labs/xandra.git", "3fb588a333ae816edeb6bda7d10dc1bad7b6ac96", [ref: "3fb588a333ae816edeb6bda7d10dc1bad7b6ac96"]},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -26,5 +26,5 @@
   "toml": {:hex, :toml, "0.7.0", "fbcd773caa937d0c7a02c301a1feea25612720ac3fa1ccb8bfd9d30d822911de", [:mix], [], "hexpm", "0690246a2478c1defd100b0c9b89b4ea280a22be9a7b313a8a058a2408a2fa70"},
   "tzdata": {:hex, :tzdata, "1.1.1", "20c8043476dfda8504952d00adac41c6eda23912278add38edc140ae0c5bcc46", [:mix], [{:hackney, "~> 1.17", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm", "a69cec8352eafcd2e198dea28a34113b60fdc6cb57eb5ad65c10292a6ba89787"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
-  "xandra": {:git, "https://github.com/blueshift-labs/xandra.git", "9a3cd6e944b19d428192d531c7bb4ec7e498be63", [ref: "9a3cd6e944b19d428192d531c7bb4ec7e498be63"]},
+  "xandra": {:git, "https://github.com/blueshift-labs/xandra.git", "512d3bec17af19374590e1c2d700095c24b4c017", [tag: "v0.14.0-bsft-29"]},
 }


### PR DESCRIPTION
Replace streaming pagination with single-page execution logic in both prepare_execute/5 and execute/4 functions. The new implementation directly uses Xandra.Cluster.execute/4 instead of stream_pages!/4, explicitly handling